### PR TITLE
Added a New Control Style Called Trigger

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DrivetrainTeleop.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DrivetrainTeleop.java
@@ -4,6 +4,7 @@ package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.util.ElapsedTime;
 import com.qualcomm.robotcore.util.Range;
 import com.qualcomm.hardware.lynx.LynxModule;
@@ -23,6 +24,16 @@ public class DrivetrainTeleop extends LinearOpMode {
         // Report Ready Over Telemetry
         telemetry.addData("Status:", "Initialized");
         telemetry.update();
+
+        // Change Control Style Based Of Driver Prefrence
+        String ControlMode = "simple";
+
+        // Setup Control Variables
+        double drive = 0;
+        double turn = 0;
+        boolean PrecisionMode = false;
+        double r_trigger = 0;
+        double l_trigger = 0;
 
         // Map Motors to Robot Configuration
         leftDrive = hardwareMap.get(DcMotor.class, "left_drive");
@@ -50,14 +61,30 @@ public class DrivetrainTeleop extends LinearOpMode {
             double leftPower;
             double rightPower;
 
-            // Get Joystick Input Values 
-            double drive = -gamepad1.left_stick_y;
-            double turn = gamepad1.left_stick_x;
+            // Check Control Mapping  (Simple vs Trigger Based)
+            if (ControlMode == "simple") {
+                drive = -gamepad1.left_stick_y;
+                turn = gamepad1.left_stick_x;
 
-            // Get Button State
-            boolean PrecisionMode = gamepad1.left_bumper;
+                // Get Left Bumper For Precision Mode
+                PrecisionMode = gamepad1.left_bumper;
+            } else if (ControlMode == "trigger") {
+                // Take Joystick input for Turning
+                turn = gamepad1.left_stick_x;
 
-            // Santitize the Input Values and calculate Drive Motor Power. 
+                // Get Circle Button For Precision Mode
+                PrecisionMode = gamepad1.circle;
+
+                // Take R and Left Trigger
+                r_trigger = gamepad1.right_trigger;
+                l_trigger = gamepad1.left_trigger;
+
+                // Calculate Drive
+                drive = r_trigger - l_trigger;
+            }
+
+
+            // Sanitize the Input Values and calculate Drive Motor Power.
             leftPower    = Range.clip(drive + turn, -1.0, 1.0);
             rightPower   = Range.clip(drive - turn, -1.0, 1.0);
 
@@ -72,7 +99,7 @@ public class DrivetrainTeleop extends LinearOpMode {
             leftDrive.setPower(leftPower);
             rightDrive.setPower(rightPower);
 
-            // Get Temperature for Telementary
+            // Get Temperature for Telemetry
             double temp = controlHub.getTemperature(TempUnit.CELSIUS);
             String Overheat = "False";
 
@@ -81,10 +108,10 @@ public class DrivetrainTeleop extends LinearOpMode {
                 Overheat = "True";
             }
 
-            // Update Telementary Data with Runtime, Motor Power, and Joystic Values
+            // Update Telemetry Data with Runtime, Motor Power, and Joystick Values
             telemetry.addData("Status: ", "Running");
             telemetry.addData("Runtime: ", runtime.toString());
-            telemetry.addData("Temprature - ", "Temp: (%.2f), Overheat: (%.2f)", temp, Overheat);
+            telemetry.addData("Temperature - ", "Temp: (%.2f), Overheat: (%.2f)", temp, Overheat);
             telemetry.addData("Input  - ", "Drive: (%.2f), Turn: (%.2f)", drive, turn);
             telemetry.addData("Motors - ", "Left: (%.2f), Right: (%.2f)", leftPower, rightPower);
             telemetry.update();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DrivetrainTeleop.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DrivetrainTeleop.java
@@ -4,7 +4,6 @@ package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotor;
-import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.util.ElapsedTime;
 import com.qualcomm.robotcore.util.Range;
 import com.qualcomm.hardware.lynx.LynxModule;
@@ -25,7 +24,7 @@ public class DrivetrainTeleop extends LinearOpMode {
         telemetry.addData("Status:", "Initialized");
         telemetry.update();
 
-        // Change Control Style Based Of Driver Prefrence
+        // Change Control Style Based Of Driver Preference
         String ControlMode = "simple";
 
         // Setup Control Variables
@@ -62,13 +61,13 @@ public class DrivetrainTeleop extends LinearOpMode {
             double rightPower;
 
             // Check Control Mapping  (Simple vs Trigger Based)
-            if (ControlMode == "simple") {
+            if ("simple".equals(ControlMode)) {
                 drive = -gamepad1.left_stick_y;
                 turn = gamepad1.left_stick_x;
 
                 // Get Left Bumper For Precision Mode
                 PrecisionMode = gamepad1.left_bumper;
-            } else if (ControlMode == "trigger") {
+            } else if ("trigger".equals(ControlMode)) {
                 // Take Joystick input for Turning
                 turn = gamepad1.left_stick_x;
 
@@ -81,6 +80,10 @@ public class DrivetrainTeleop extends LinearOpMode {
 
                 // Calculate Drive
                 drive = r_trigger - l_trigger;
+            } else {
+                drive = 0;
+                turn = 0;
+                PrecisionMode = false;
             }
 
 
@@ -111,7 +114,7 @@ public class DrivetrainTeleop extends LinearOpMode {
             // Update Telemetry Data with Runtime, Motor Power, and Joystick Values
             telemetry.addData("Status: ", "Running");
             telemetry.addData("Runtime: ", runtime.toString());
-            telemetry.addData("Temperature - ", "Temp: (%.2f), Overheat: (%.2f)", temp, Overheat);
+            telemetry.addData("Temperature - ", "Temp: (%.2f), Overheat: (%s)", temp, Overheat);
             telemetry.addData("Input  - ", "Drive: (%.2f), Turn: (%.2f)", drive, turn);
             telemetry.addData("Motors - ", "Left: (%.2f), Right: (%.2f)", leftPower, rightPower);
             telemetry.update();


### PR DESCRIPTION
This pull request adds support for switching between two different control schemes ("simple" and "trigger") in the `DrivetrainTeleop` class, allowing drivers to choose their preferred style for operating the robot. It also includes minor telemetry improvements and fixes some typos.

Control scheme selection and input mapping:

* Introduced a `ControlMode` variable to allow switching between "simple" (joystick-based) and "trigger" (trigger/button-based) driving styles. Input handling now adapts based on the selected mode, including different buttons for precision mode and drive calculation. [[1]](diffhunk://#diff-73441b3181f8b1ea63729b721de5f09bbe895707317a23d7389a064eb2e80318R27-R36) [[2]](diffhunk://#diff-73441b3181f8b1ea63729b721de5f09bbe895707317a23d7389a064eb2e80318L53-R90)

Telemetry and code quality improvements:

* Corrected typos in telemetry comments and data labels (e.g., "Telementary" to "Telemetry", "Joystic" to "Joystick", "Temprature" to "Temperature") for better clarity. [[1]](diffhunk://#diff-73441b3181f8b1ea63729b721de5f09bbe895707317a23d7389a064eb2e80318L75-R105) [[2]](diffhunk://#diff-73441b3181f8b1ea63729b721de5f09bbe895707317a23d7389a064eb2e80318L84-R117)